### PR TITLE
04_localStorageDTO

### DIFF
--- a/src/components/paintboard/index.tsx
+++ b/src/components/paintboard/index.tsx
@@ -11,7 +11,7 @@ const PaintBoard = () => {
     upX = 0,
     upY = 0;
   const [selectedShape, setSelectedShape] = useState<Shapes>("square");
-  const { shapes, addShapes, clearShapes } = useShapes();
+  const { shapes, initShapes, addShapes, clearShapes } = useShapes();
 
   return (
     <div>
@@ -51,6 +51,7 @@ const PaintBoard = () => {
         </div>
       </div>
       <main
+        ref={initShapes}
         id="canvas"
         className="w-full h-screen overflow-hidden"
         onMouseDown={(e) => {

--- a/src/hooks/useShapes.tsx
+++ b/src/hooks/useShapes.tsx
@@ -1,23 +1,34 @@
 import { ShapeType } from "@/types/shape";
-import { useState } from "react";
+import { getLocalStorageShapeData, setLocalStorageShapeData } from "@/util/LocalStorageDTO";
+import { useCallback, useState } from "react";
 
 const useShapes = () => {
   const [shapes, setShapes] = useState<ShapeType[]>([]);
+
+  const initShapes = useCallback((node: HTMLDivElement) => {
+    if (node == null) {
+      return;
+    }
+
+    setShapes(getLocalStorageShapeData());
+  }, []);
 
   const addShapes = (shapeData: ShapeType) => {
     const { left, top, width, height, shape } = shapeData;
     setShapes((prev) => {
       const newState = [...prev];
       newState.push({ left, top, width, height, shape });
+      setLocalStorageShapeData(newState);
       return newState;
     });
   };
 
   const clearShapes = () => {
     setShapes([]);
+    setLocalStorageShapeData([]);
   };
 
-  return { shapes, addShapes, clearShapes };
+  return { shapes, initShapes, addShapes, clearShapes };
 };
 
 export default useShapes;

--- a/src/util/LocalStorageDTO.ts
+++ b/src/util/LocalStorageDTO.ts
@@ -1,0 +1,7 @@
+import { ShapeType } from "@/types/shape";
+
+export const getLocalStorageShapeData = () => JSON.parse(localStorage.getItem("shapes") ?? "[]");
+
+export const setLocalStorageShapeData = (shapes: ShapeType[]) => {
+  localStorage.setItem("shapes", JSON.stringify(shapes));
+};


### PR DESCRIPTION
# DONE
- 로컬 저장소 접근하기 위한 주체 DTO 를 생성
  - getter/setter 는 여기서만 구성한다.
- 기존에 addShapes 와 clearShapes 에 setter 함수를 적용
- 스토리지 내용을 사용할 수 있도록

# TODO
- 변형이 일어날 때마다 setter 를 걸어줘야 하는데 이로 인한 보일러 플레이트가 많이 일어난다. 개선의 여지가 분명 있을까?
- 하이드레이션이 완료되기까지 초기화가 시간이 다소 걸린다. 이를 극복할 방법은 없을까?