### PR TITLE
07_Modify

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: false,
+};
 
 export default nextConfig;

--- a/src/components/UI/ToolButton.tsx
+++ b/src/components/UI/ToolButton.tsx
@@ -1,4 +1,3 @@
-import { MouseEventHandler } from "react";
 import clsx from "clsx";
 
 const ToolButton = ({
@@ -8,14 +7,19 @@ const ToolButton = ({
 }: Readonly<{
   children: React.ReactNode;
   active?: boolean;
-  onClick?: MouseEventHandler<HTMLDivElement>;
+  onClick?: () => void;
 }>): JSX.Element => {
   return (
     <div
-      className={clsx("w-10 h-10 py-2 border-2 shadow-2xl cursor-pointer font-bold", {
-        "border-black": active,
-      })}
-      onClick={onClick}
+      className={clsx(
+        "w-10 h-10 py-2 border-2 text-[12px] text-center shadow-2xl leading-[12px] cursor-pointer font-bold",
+        {
+          "border-black": active,
+        }
+      )}
+      onClick={() => {
+        onClick();
+      }}
     >
       {children}
     </div>

--- a/src/components/paintboard/DrawEventComponent.tsx
+++ b/src/components/paintboard/DrawEventComponent.tsx
@@ -1,9 +1,15 @@
-import { ShapeAttributes } from "@/types/shape";
+import { ShapeAttributes, Shapes, ShapeType } from "@/types/shape";
 import { DrawingShapeDataCalculator } from "@/util/ShapeDataCalculator";
 import { useRef } from "react";
 import { DrawingShape } from "./DrawnShapes";
 
-const DrawEventComponent = ({ shape, addShapes }: any) => {
+const DrawEventComponent = ({
+  shape,
+  addShapes,
+}: {
+  shape: Shapes;
+  addShapes: (shapeData: ShapeType) => void;
+}) => {
   const previewRef = useRef<HTMLDivElement>(null);
   const shapeDataCalculator = new DrawingShapeDataCalculator();
 

--- a/src/components/paintboard/DrawnShapes/index.tsx
+++ b/src/components/paintboard/DrawnShapes/index.tsx
@@ -41,7 +41,10 @@ const DrawnShapes = ({
         return (
           <ShapeComponent
             tabIndex={mode === "modify" ? 0 : undefined}
-            onClick={() => setIndex(idx)}
+            onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+              e.stopPropagation();
+              setIndex(idx);
+            }}
             key={idx}
             $mode={mode}
             $top={top}

--- a/src/components/paintboard/ModifyEventComponent.tsx
+++ b/src/components/paintboard/ModifyEventComponent.tsx
@@ -54,15 +54,18 @@ const ModifyEventComponent = ({
       <ShapeComponent
         onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => {
           e.preventDefault();
+          e.stopPropagation();
           ShapeDataCalculator.setOffset(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
         }}
         onMouseMove={(e: React.MouseEvent<HTMLDivElement>) => {
+          e.stopPropagation();
           if (e.buttons === 1) {
             const { left, top } = ShapeDataCalculator.calcShapeData(e.clientX, e.clientY);
             setMovingShape({ left, top, width, height });
           }
         }}
         onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+          e.stopPropagation();
           const { left, top } = ShapeDataCalculator.calcShapeData(e.clientX, e.clientY);
           const newState = { ...selectedShape, left, top };
           moveShape(index, newState);

--- a/src/components/paintboard/ToolBar/index.tsx
+++ b/src/components/paintboard/ToolBar/index.tsx
@@ -1,62 +1,76 @@
 import ToolButton from "@/components/UI/ToolButton";
-import { Modes } from "@/types/mode";
+import { Modes, ModifyMethods } from "@/types/mode";
 import { Shapes } from "@/types/shape";
-import React, { Dispatch, SetStateAction } from "react";
+import React, { ReactNode } from "react";
 
-const ToolBar = ({
+export const Draw = ({
   mode,
-  setMode,
-  clearShapes,
   shape,
-  setShape,
+  ToolClickHandler,
 }: {
   mode: Modes;
-  setMode: Dispatch<SetStateAction<Modes>>;
   shape: Shapes;
-  setShape: Dispatch<SetStateAction<Shapes>>;
-  clearShapes: () => void;
-}): JSX.Element => {
+  ToolClickHandler: (mode: Modes, shape?: Shapes) => () => void;
+}) => {
   return (
-    <div className="w-full flex bg-black">
-      <div className="flex items-center bg-white">
-        <ToolButton
-          active={mode === "draw" && shape === "square"}
-          onClick={() => {
-            setMode("draw");
-            setShape("square");
-          }}
-        >
-          <div className="border-2 mx-2 h-full border-black" />
-        </ToolButton>
-        <ToolButton
-          active={mode === "draw" && shape === "circle"}
-          onClick={() => {
-            setMode("draw");
-            setShape("circle");
-          }}
-        >
-          <div className="border-2 mx-2 h-full rounded-full border-black" />
-        </ToolButton>
-        <ToolButton
-          active={mode === "modify"}
-          onClick={() => {
-            setMode("modify");
-          }}
-        >
-          선택
-        </ToolButton>
-
-        <ToolButton
-          active={false}
-          onClick={() => {
-            clearShapes();
-          }}
-        >
-          삭제
-        </ToolButton>
-      </div>
-    </div>
+    <WhiteBackground>
+      <ToolButton
+        active={mode === "draw" && shape === "square"}
+        onClick={ToolClickHandler("draw", "square")}
+      >
+        <div className="border-2 mx-2 h-full border-black" />
+      </ToolButton>
+      <ToolButton
+        active={mode === "draw" && shape === "circle"}
+        onClick={ToolClickHandler("draw", "circle")}
+      >
+        <div className="border-2 mx-2 h-full rounded-full border-black" />
+      </ToolButton>
+    </WhiteBackground>
   );
 };
 
-export default ToolBar;
+export const Clear = ({ clearShapes }: { clearShapes: () => void }) => {
+  return (
+    <WhiteBackground>
+      <ToolButton onClick={clearShapes}>초기화</ToolButton>
+    </WhiteBackground>
+  );
+};
+
+export const Modify = ({
+  mode,
+  index,
+  ToolClickHandler,
+  modifyShape,
+}: {
+  mode: Modes;
+  index: number;
+  ToolClickHandler: (mode: Modes) => () => void;
+  modifyShape: ModifyMethods;
+}) => {
+  return (
+    <>
+      <WhiteBackground>
+        <ToolButton active={mode === "modify"} onClick={ToolClickHandler("modify")}>
+          수정
+        </ToolButton>
+      </WhiteBackground>
+      <div
+        className={`${
+          index < 0 ? "pointer-events-none cursor-auto bg-gray-500 text-gray-400" : " bg-white"
+        } flex bg-white`}
+      >
+        <ToolButton onClick={modifyShape.top}>맨앞으로</ToolButton>
+        <ToolButton onClick={modifyShape.forward}>앞으로</ToolButton>
+        <ToolButton onClick={modifyShape.backward}>뒤로</ToolButton>
+        <ToolButton onClick={modifyShape.bottom}>맨뒤로</ToolButton>
+        <ToolButton onClick={modifyShape.delete}>지우기</ToolButton>
+      </div>
+    </>
+  );
+};
+
+const WhiteBackground = ({ children }: { children: ReactNode }) => {
+  return <div className="flex items-center bg-white">{children}</div>;
+};

--- a/src/components/paintboard/canvas/index.tsx
+++ b/src/components/paintboard/canvas/index.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from "react";
+
+const Canvas = ({
+  children,
+  initShapes,
+  onClickHandler,
+}: {
+  children: ReactNode;
+  initShapes: (node: HTMLDivElement) => void;
+  onClickHandler: (e: React.MouseEvent<HTMLDivElement>) => void;
+}): JSX.Element => {
+  return (
+    <div
+      ref={initShapes}
+      id="canvas"
+      className="w-full h-[calc(100vh-40px)] overflow-hidden"
+      onClick={onClickHandler}
+    >
+      {children}
+    </div>
+  );
+};
+export default Canvas;

--- a/src/components/paintboard/index.tsx
+++ b/src/components/paintboard/index.tsx
@@ -3,29 +3,54 @@ import { Shapes } from "@/types/shape";
 import { useState } from "react";
 import useShapes from "@/hooks/useShapes";
 import DrawnShapes from "./DrawnShapes";
-import ToolBar from "./ToolBar";
+import * as ToolBar from "./ToolBar";
 import { Modes } from "@/types/mode";
 import DrawEventComponent from "./DrawEventComponent";
 import ModifyEventComponent from "./ModifyEventComponent";
+import Canvas from "./canvas";
 
 const PaintBoard = (): JSX.Element => {
   const [shape, setShape] = useState<Shapes>("square");
   const [mode, setMode] = useState<Modes>("draw");
-  const { drawnShapes, initShapes, addShapes, clearShapes, index, setIndex, moveShape } =
-    useShapes();
+  const {
+    drawnShapes,
+    initShapes,
+    addShapes,
+    clearShapes,
+    index,
+    setIndex,
+    moveShape,
+    modifyShape,
+  } = useShapes(mode);
+  console.count("RERENDER");
+  console.log(drawnShapes);
+
+  const ToolClickHandler = (mode: Modes, shape?: Shapes) => () => {
+    setMode(mode);
+    if (shape !== undefined) {
+      setShape(shape);
+    }
+  };
+
+  const resetIndex = () => {
+    setIndex(-1);
+  };
 
   return (
     <div>
-      <ToolBar
-        mode={mode}
-        setMode={setMode}
-        clearShapes={clearShapes}
-        shape={shape}
-        setShape={setShape}
-      />
-      <div ref={initShapes} id="canvas" className="w-full h-screen overflow-hidden">
-        {mode === "draw" && <DrawEventComponent shape={shape} addShapes={addShapes} />}
+      <div className="w-full flex bg-black z-10">
+        <ToolBar.Draw mode={mode} ToolClickHandler={ToolClickHandler} shape={shape} />
+        <ToolBar.Clear clearShapes={clearShapes} />
+        <ToolBar.Modify
+          mode={mode}
+          ToolClickHandler={ToolClickHandler}
+          index={index}
+          modifyShape={modifyShape}
+        />
+      </div>
+      <Canvas initShapes={initShapes} onClickHandler={resetIndex}>
         <DrawnShapes shapes={drawnShapes} mode={mode} setIndex={setIndex} />
+        {mode === "draw" && <DrawEventComponent shape={shape} addShapes={addShapes} />}
         {mode === "modify" && (
           <ModifyEventComponent
             selectedShape={drawnShapes[index]}
@@ -33,7 +58,7 @@ const PaintBoard = (): JSX.Element => {
             moveShape={moveShape}
           />
         )}
-      </div>
+      </Canvas>
     </div>
   );
 };

--- a/src/hooks/useShapes.tsx
+++ b/src/hooks/useShapes.tsx
@@ -1,12 +1,13 @@
+import { Modes } from "@/types/mode";
 import { ShapeType } from "@/types/shape";
 import {
   deleteLocalStorageShapeData,
   getLocalStorageShapeData,
   setLocalStorageShapeData,
 } from "@/util/LocalStorageDTO";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-const useShapes = () => {
+const useShapes = (mode: Modes) => {
   const [drawnShapes, setDrawnShapes] = useState<ShapeType[]>([]);
   const [index, setIndex] = useState<number>(-1);
 
@@ -14,25 +15,29 @@ const useShapes = () => {
     if (node == null) {
       return;
     }
-
     setDrawnShapes(getLocalStorageShapeData());
   }, []);
+
+  const resetIndex = () => {
+    if (index !== -1) {
+      setIndex(-1);
+    }
+  };
+
+  // 그리기 모드일때 index 초기화
+  useEffect(() => {
+    if (mode === "draw") resetIndex();
+  }, [mode]);
+
+  useEffect(() => {
+    setLocalStorageShapeData(drawnShapes);
+  }, [drawnShapes]);
 
   const addShapes = (shapeData: ShapeType) => {
     const { left, top, width, height, shape } = shapeData;
     setDrawnShapes((prev) => {
       const newState = [...prev];
       newState.push({ left, top, width, height, shape });
-      setLocalStorageShapeData(newState);
-      return newState;
-    });
-  };
-
-  const moveShape = (index: number, shapeData: ShapeType) => {
-    setDrawnShapes((prev) => {
-      const newState = [...prev];
-      newState[index] = shapeData;
-      setLocalStorageShapeData(newState);
       return newState;
     });
   };
@@ -42,7 +47,75 @@ const useShapes = () => {
     deleteLocalStorageShapeData();
   };
 
-  return { drawnShapes, initShapes, addShapes, moveShape, clearShapes, index, setIndex };
+  const modifyShape = {
+    invoke: () => {
+      const targetShape = drawnShapes[index];
+      const remainShapes = [...drawnShapes];
+      remainShapes.splice(index, 1);
+      return { targetShape, remainShapes };
+    },
+    top: () => {
+      const { targetShape, remainShapes } = modifyShape.invoke();
+      const toIndex = drawnShapes.length - 1;
+      setIndex(toIndex);
+      const newState = [...remainShapes, targetShape];
+      setDrawnShapes(newState);
+    },
+    forward: () => {
+      const { targetShape, remainShapes } = modifyShape.invoke();
+      const toIndex = Math.min(index + 1, drawnShapes.length - 1);
+      setIndex(toIndex);
+      const newState = [
+        ...remainShapes.slice(0, toIndex),
+        targetShape,
+        ...remainShapes.slice(toIndex),
+      ];
+      setDrawnShapes(newState);
+    },
+    backward: () => {
+      const { targetShape, remainShapes } = modifyShape.invoke();
+      const toIndex = Math.max(index - 1, 0);
+      setIndex(toIndex);
+      const newState = [
+        ...remainShapes.slice(0, toIndex),
+        targetShape,
+        ...remainShapes.slice(toIndex),
+      ];
+      setDrawnShapes(newState);
+    },
+    bottom: () => {
+      const { targetShape, remainShapes } = modifyShape.invoke();
+      const toIndex = 0;
+      setIndex(toIndex);
+      const newState = [targetShape, ...remainShapes];
+      setDrawnShapes(newState);
+    },
+    delete: () => {
+      const remainShapes = [...drawnShapes];
+      remainShapes.splice(index, 1);
+      resetIndex();
+      setDrawnShapes(remainShapes);
+    },
+  };
+
+  const moveShape = (index: number, shapeData: ShapeType) => {
+    setDrawnShapes((prev) => {
+      const newState = [...prev];
+      newState[index] = shapeData;
+      return newState;
+    });
+  };
+
+  return {
+    drawnShapes,
+    initShapes,
+    addShapes,
+    moveShape,
+    clearShapes,
+    index,
+    setIndex,
+    modifyShape,
+  };
 };
 
 export default useShapes;

--- a/src/types/mode.ts
+++ b/src/types/mode.ts
@@ -1,1 +1,15 @@
+import { ShapeType } from "./shape";
+
 export type Modes = "draw" | "modify";
+
+export type ModifyMethods = {
+  invoke: () => {
+    targetShape: ShapeType;
+    remainShapes: ShapeType[];
+  };
+  top: () => void;
+  forward: () => void;
+  backward: () => void;
+  bottom: () => void;
+  delete: () => void;
+};


### PR DESCRIPTION
# 선택한 모양 편집

## Done
- 맨 위로, 위로, 아래로, 맨 아래로 버튼 구현 완료
- 커스텀훅 기능들 정리, 각각 필요한 곳에서만 사용하도록 분리
- 툴바 기능별로 분리
- 컴포넌트 재구성
  - 적은 props 로 대응할 수 있도록 툴바 컴포넌트 분리
  - canvas 컴포넌트 분리
  - ToolButton active 와 disabled 를 관리하기 쉽도록 수정
- 선택중일때 배경을 클릭하면 선택이 제외되도록 변경
  - modify, draw 컴포넌트의 이벤트 핸들러에 stopPropagation적용
- 리랜더링 테스트 하기 쉽도록 ReactStrinctMode 해제

## TODO
- 지속적인 리팩토링
- 선택한 도형 크기조절 기능